### PR TITLE
Add unified time formatting

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ function displayTime() {
     
     timeHoursElement.innerText = String(timeHours).padStart(2, "0")
     timeMinutesElement.innerText = String(timeMinutes).padStart(2, "0")
-    timeSecondsElement.innerText = String(timeSeconds.padStart(2, "0")
+    timeSecondsElement.innerText = String(timeSeconds).padStart(2, "0")
 }
 
 setInterval(displayTime, 100)

--- a/src/index.js
+++ b/src/index.js
@@ -8,9 +8,10 @@ function displayTime() {
     const timeHoursElement = document.getElementById('time-hours')
     const timeMinutesElement = document.getElementById('time-minutes')
     const timeSecondsElement = document.getElementById('time-seconds')
-    timeHoursElement.innerText = timeHours
-    timeMinutesElement.innerText = timeMinutes
-    timeSecondsElement.innerText = timeSeconds
+    
+    timeHoursElement.innerText = String(timeHours).padStart(2, "0")
+    timeMinutesElement.innerText = String(timeMinutes).padStart(2, "0")
+    timeSecondsElement.innerText = String(timeSeconds.padStart(2, "0")
 }
 
 setInterval(displayTime, 100)


### PR DESCRIPTION
Numbers less than 10 will now be displayed with leading zeros to
display the time in a unified way. This prevents the clock from
resizing with the displayed text.